### PR TITLE
[Setting] #37 - Settings, info에 APNS 기본 세팅 추가

### DIFF
--- a/SOPT-iOS/Plugins/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
+++ b/SOPT-iOS/Plugins/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
@@ -48,6 +48,7 @@ public extension SettingsDictionary {
         merging(["CODE_SIGN_STYLE": SettingValue(stringLiteral: "Manual")])
             .merging(["DEVELOPMENT_TEAM": SettingValue(stringLiteral: "9K86FQHDLU")])
             .merging(["CODE_SIGN_IDENTITY": SettingValue(stringLiteral: "iPhone Developer")])
+            .merging(["CODE_SIGN_ENTITLEMENTS": SettingValue(stringLiteral: "SOPT-iOS.entitlements")])
     }
     
     func setProvisioningDevelopment() -> SettingsDictionary {

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
@@ -27,7 +27,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneDidDisconnect(_ scene: UIScene) {}
 
-    func sceneDidBecomeActive(_ scene: UIScene) {}
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        UIApplication.shared.applicationIconBadgeNumber = 0
+    }
 
     func sceneWillResignActive(_ scene: UIScene) {}
 

--- a/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -101,7 +101,8 @@ public extension Project {
             ],
             "App Transport Security Settings": ["Allow Arbitrary Loads": true],
             "NSAppTransportSecurity": ["NSAllowsArbitraryLoads": true],
-            "ITSAppUsesNonExemptEncryption": false
+            "ITSAppUsesNonExemptEncryption": false,
+            "UIBackgroundModes": ["fetch", "remote-notification"]
         ]
 }
 


### PR DESCRIPTION
### 🛠 작업 내용
<!-- 작업한 내용을 적어주세요. -->
- SettingsDictionary+에 CODE_SIGN_ENTITLEMENTS 추가
- infoplist에 UIBackgroundModes 추가

### 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
다시 generate하시면 push notification과 background fetch, remote notifications가 선택된 background modes가 추가되어 있을거에여
머지 후 풀 받아서 확인부탁드림니당

### 📸 스크린샷
<img width="888" alt="스크린샷 2022-10-18 오후 5 27 01" src="https://user-images.githubusercontent.com/81167570/196377859-d703417f-777a-419e-ae03-83081f4e4f77.png">

### 💡 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. -->
closed #37 
