### PR TITLE
[Setting] #42 - Network 레이어 수정, PostDetailTransform 추가

### DIFF
--- a/SOPT-iOS/Plugins/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
+++ b/SOPT-iOS/Plugins/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
@@ -48,6 +48,12 @@ public extension SettingsDictionary {
         merging(["CODE_SIGN_STYLE": SettingValue(stringLiteral: "Manual")])
             .merging(["DEVELOPMENT_TEAM": SettingValue(stringLiteral: "9K86FQHDLU")])
             .merging(["CODE_SIGN_IDENTITY": SettingValue(stringLiteral: "iPhone Developer")])
+    }
+    
+    func setCodeSignManualForApp() -> SettingsDictionary {
+        merging(["CODE_SIGN_STYLE": SettingValue(stringLiteral: "Manual")])
+            .merging(["DEVELOPMENT_TEAM": SettingValue(stringLiteral: "9K86FQHDLU")])
+            .merging(["CODE_SIGN_IDENTITY": SettingValue(stringLiteral: "iPhone Developer")])
             .merging(["CODE_SIGN_ENTITLEMENTS": SettingValue(stringLiteral: "SOPT-iOS.entitlements")])
     }
     

--- a/SOPT-iOS/Projects/Data/Sources/Transform/PostDetailTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/PostDetailTransform.swift
@@ -1,16 +1,17 @@
 //
-//  PostDetailEntity.swift
-//  Presentation
+//  PostDetailTransform.swift
+//  Data
 //
-//  Created by Junho Lee on 2022/10/10.
+//  Created by 양수빈 on 2022/10/19.
 //  Copyright © 2022 SOPT-iOS. All rights reserved.
 //
 
 import Foundation
 
 import Domain
+import Network
 
-public struct PostDetailEntity {
+extension PostDetailEntity {
 
     public func toDomain() -> PostDetailModel {
         return PostDetailModel.init()

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/PostDetailEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/PostDetailEntity.swift
@@ -8,13 +8,18 @@
 
 import Foundation
 
-public struct MainMapEntity: Codable {
-    public let id, name: String
-    public let longitude, latitude: Double
-    public let isDietRestaurant: Bool
+//public struct MainMapEntity: Codable {
+//    public let id, name: String
+//    public let longitude, latitude: Double
+//    public let isDietRestaurant: Bool
+//
+//    enum CodingKeys: String, CodingKey {
+//        case id = "_id"
+//        case name, longitude, latitude, isDietRestaurant
+//    }
+//}
 
-    enum CodingKeys: String, CodingKey {
-        case id = "_id"
-        case name, longitude, latitude, isDietRestaurant
-    }
+public struct PostDetailEntity {
+
+    
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/AlertService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/AlertService.swift
@@ -15,16 +15,16 @@ import Combine
 public typealias DefaultAlertService = BaseService<AlertAPI>
 
 public protocol AlertService {
-    func getRestaurant() -> AnyPublisher<[MainMapEntity]?, Error>
-    func commonRestaurant(completion: @escaping (Result<[MainMapEntity]?, Error>) -> Void)
+//    func getRestaurant() -> AnyPublisher<[MainMapEntity]?, Error>
+//    func commonRestaurant(completion: @escaping (Result<[MainMapEntity]?, Error>) -> Void)
 }
 
 extension DefaultAlertService: AlertService {
-    public func getRestaurant() -> AnyPublisher<[MainMapEntity]?, Error> {
-        return requestObjectInCombine(.restaurant)
-    }
-    
-    public func commonRestaurant(completion: @escaping (Result<[MainMapEntity]?, Error>) -> Void) {
-        return requestObject(.restaurant, completion: completion)
-    }
+//    public func getRestaurant() -> AnyPublisher<[MainMapEntity]?, Error> {
+//        return requestObjectInCombine(.restaurant)
+//    }
+//
+//    public func commonRestaurant(completion: @escaping (Result<[MainMapEntity]?, Error>) -> Void) {
+//        return requestObject(.restaurant, completion: completion)
+//    }
 }

--- a/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -20,8 +20,8 @@ public extension Project {
         /// - configurations: project의 configurations 설정
         /// - defaultSettings: xcconfig 사용하는 경우 .none으로 하는게 편함
         let settings: Settings = .settings(
-            base: .init()
-                .setCodeSignManual(),
+            base:
+                product == .app ? .init().setCodeSignManualForApp() : .init().setCodeSignManual(),
             debug: .init()
                 .setProvisioningDevelopment(),
             release: .init()


### PR DESCRIPTION
### 🛠 작업 내용
<!-- 작업한 내용을 적어주세요. -->
[여기](https://github.com/TeamRecorDream/RecorDream-iOS/pull/25/files)를 참고하여 네트워크 레이어 수정했습니다.
- Data 모듈에 Transform 폴더 추가
- Network 모듈로 Entity 이동, toDomain 함수 Transform으로 분리

### 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
PostDetailTransform 추가하고, 기존에 Network에 있던 PostDetailEntity 내부 주석 처리 후 수정했습니다

### 📸 스크린샷
<img width="383" alt="스크린샷 2022-10-19 오전 3 06 14" src="https://user-images.githubusercontent.com/81167570/196509906-a3dd172c-0d09-4424-9f9f-c40657e65a2a.png">
<img width="375" alt="스크린샷 2022-10-19 오전 3 06 29" src="https://user-images.githubusercontent.com/81167570/196509968-69622a39-f97f-458a-aaae-990835c6a61e.png">

### 💡 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. -->
closed #42 
