### PR TITLE
[Feat] #46 - CustomNaviagtionBar

### DIFF
--- a/SOPT-iOS/Projects/Presentation/Sources/Components/CustomNavigationBar.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/Components/CustomNavigationBar.swift
@@ -1,0 +1,183 @@
+//
+//  CustomNavigationBar.swift
+//  Presentation
+//
+//  Created by 양수빈 on 2022/10/20.
+//  Copyright © 2022 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import SnapKit
+
+import DSKit
+
+@frozen
+enum naviType {
+    case leftTitle
+    case leftTitleWithLeftButton
+    case onlyRightButton
+}
+
+class CustomNavigationBar: UIView {
+    
+    // MARK: - UI Component
+    
+    private var vc: UIViewController?
+    private let titleLabel = UILabel()
+    private let leftButton = UIButton()
+    private let rightButton = UIButton()
+    private let otherRightButton = UIButton()
+    
+    // MARK: - Properties
+    
+    private var rightButtonClosure: (() -> Void)?
+    private var otherRightButtonClosure: (() -> Void)?
+    
+    // MARK: - Initialize
+    
+    init(_ vc: UIViewController, type: naviType) {
+        super.init(frame: .zero)
+        self.vc = vc
+        self.setUI(type)
+        self.setLayout(type)
+        self.setAddTarget()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Method
+
+extension CustomNavigationBar {
+    private func setAddTarget() {
+        self.leftButton.addTarget(self, action: #selector(popToPreviousVC), for: .touchUpInside)
+    }
+    
+    @discardableResult
+    func setTitle(_ title: String) -> Self {
+        self.titleLabel.text = title
+        return self
+    }
+    
+    @discardableResult
+    func setRightButtonTitle(_ title: String) -> Self {
+        self.rightButton.setTitle(title, for: .normal)
+        return self
+    }
+    
+    @discardableResult
+    func rightButtonAction(_ closure: (() -> Void)? = nil) -> Self {
+        self.rightButtonClosure = closure
+        self.rightButton.addTarget(self, action: #selector(touchupRightButton), for: .touchUpInside)
+        return self
+    }
+    
+    @discardableResult
+    func otherRightButtonAction(_ closure: (() -> Void)? = nil) -> Self {
+        self.otherRightButtonClosure = closure
+        self.otherRightButton.addTarget(self, action: #selector(touchupOtherRightButton), for: .touchUpInside)
+        return self
+    }
+    
+    // MARK: - @objc
+    
+    @objc
+    private func popToPreviousVC() {
+        self.vc?.navigationController?.popViewController(animated: true)
+    }
+    
+    @objc
+    private func touchupRightButton() {
+        self.rightButtonClosure?()
+    }
+    
+    @objc
+    private func touchupOtherRightButton() {
+        self.otherRightButtonClosure?()
+    }
+}
+
+// MARK: - UI & Layout
+
+extension CustomNavigationBar {
+    private func setUI(_ type: naviType) {
+        leftButton.setImage(UIImage(asset: DSKitAsset.Assets.icBack), for: .normal)
+        
+        titleLabel.setTypoStyle(.h5)
+        titleLabel.textColor = DSKitAsset.Colors.gray900.color
+        
+        switch type {
+        case .leftTitle:
+            rightButton.setImage(UIImage(asset: DSKitAsset.Assets.icSetting), for: .normal)
+            otherRightButton.setImage(UIImage(asset: DSKitAsset.Assets.icSearch), for: .normal)
+        case .leftTitleWithLeftButton, .onlyRightButton:
+            rightButton.setTitleColor(DSKitAsset.Colors.blue500.color, for: .normal)
+            rightButton.titleLabel?.setTypoStyle(.body1)
+        }
+    }
+    
+    private func setLayout(_ type: naviType) {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(56)
+        }
+        
+        switch type {
+        case .leftTitle:
+            self.setLeftTitleLayout()
+        case .leftTitleWithLeftButton:
+            self.setLeftTitleWithButtonLayout()
+            self.setRightButtonLayout()
+        case .onlyRightButton:
+            self.setRightButtonLayout()
+        }
+    }
+    
+    private func setLeftTitleLayout() {
+        self.addSubviews(titleLabel, rightButton, otherRightButton)
+        
+        titleLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(16)
+        }
+        
+        rightButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().inset(8)
+            make.width.height.equalTo(40)
+        }
+        
+        otherRightButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalTo(rightButton.snp.leading)
+            make.width.height.equalTo(40)
+        }
+    }
+    
+    private func setLeftTitleWithButtonLayout() {
+        self.addSubviews(leftButton, titleLabel)
+        
+        leftButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(8)
+            make.width.height.equalTo(40)
+        }
+        
+        titleLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(leftButton.snp.trailing)
+        }
+    }
+    
+    private func setRightButtonLayout() {
+        self.addSubviews(rightButton)
+        
+        rightButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(40)
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Presentation/Sources/Components/CustomNavigationBar.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/Components/CustomNavigationBar.swift
@@ -81,9 +81,11 @@ extension CustomNavigationBar {
         self.otherRightButton.addTarget(self, action: #selector(touchupOtherRightButton), for: .touchUpInside)
         return self
     }
-    
-    // MARK: - @objc
-    
+}
+
+// MARK: - @objc
+
+extension CustomNavigationBar {
     @objc
     private func popToPreviousVC() {
         self.vc?.navigationController?.popViewController(animated: true)

--- a/SOPT-iOS/Projects/Presentation/Sources/PostDetailScene/VC/PostDetailVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostDetailScene/VC/PostDetailVC.swift
@@ -27,6 +27,9 @@ public class PostDetailVC: UIViewController {
   
     // MARK: - UI Components
     
+    private lazy var naviBar = CustomNavigationBar(self, type: .leftTitleWithLeftButton)
+        .setTitle("전체")
+    
     private lazy var postDetailCollectionView: UICollectionView = {
         let cv = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout())
         cv.showsVerticalScrollIndicator = true
@@ -59,10 +62,15 @@ extension PostDetailVC {
     }
     
     private func setLayout() {
-        self.view.addSubviews(postDetailCollectionView)
+        self.view.addSubviews(naviBar, postDetailCollectionView)
+        
+        naviBar.snp.makeConstraints { make in
+            make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
         
         postDetailCollectionView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.top.equalTo(naviBar.snp.bottom)
+            make.leading.trailing.bottom.equalToSuperview()
         }
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/VC/PostListVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/VC/PostListVC.swift
@@ -22,6 +22,15 @@ public class PostListVC: UIViewController {
   
     // MARK: - UI Components
     
+    private lazy var naviBar = CustomNavigationBar(self, type: .leftTitle)
+        .setTitle("공지")
+        .rightButtonAction {
+            print("rightButtonAction")
+        }
+        .otherRightButtonAction {
+            print("otherRightButtonAction")
+        }
+    
     private lazy var postListViewPager: ViewPager = {
         let viewPager = ViewPager(tabSizeConfiguration: .fixed(width: 72, height: 32))
         
@@ -54,9 +63,15 @@ extension PostListVC {
     }
     
     private func setLayout() {
-        self.view.addSubviews(postListViewPager)
+        self.view.addSubviews(naviBar, postListViewPager)
+        
+        naviBar.snp.makeConstraints { make in
+            make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
+        
         postListViewPager.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaLayoutGuide)
+            make.top.equalTo(naviBar.snp.bottom)
+            make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
 }


### PR DESCRIPTION
### 🛠 작업 내용
<!-- 작업한 내용을 적어주세요. -->
- CustomNavigationBar 생성
- PostListVC, PostDetailVC에 네비바 적용

### 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
네비바 종류를 세가지로 나눴습니다.. 조금 정신없을 수 있슴니다 .. 
(naviType 종류 이름이 쪼금 어떻게 지어도 애매한거같아서 아이디어 의견 받어여)
- leftTitle: 왼쪽에 타이틀만 있는 경우 (PostListVC)
- leftTitleWithLeftButton: 왼쪽에 백버튼과 타이틀, 오른쪽 버튼이 있는 경우 (PostDetailVC)
- onlyRightButton: 오른쪽 버튼만 있는 경우 (회원가입)
```
@frozen
enum naviType {
    case leftTitle
    case leftTitleWithLeftButton
    case onlyRightButton
}
```

**사용가능한 메소드**
```
// 네비바 타이틀 설정 
setTitle("전체")

// rightButton 타이틀 설정 
setRightButtonTitle("인증하기")

// rightButton 액션 설정
rightButtonAction { 
    // 여기 넣어주세욜 
}

// otherRightButton 액션 설정
otherRightButtonAction {
    // 여기
}
```
- 지금까지 leftButton은 모두 backButton이라 따로 액션 넣도록 하지 않고 CustomNavigationBar 자체에 popToPreviousVC로 넣어뒀습니다

**사용 예시**
```
    private lazy var naviBar = CustomNavigationBar(self, type: .leftTitle)
        .setTitle("공지")
        
    naviBar.rightButtonAction {
            print("rightButtonAction")
        }
        .otherRightButtonAction {
            print("otherRightButtonAction")
        }
```

### 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| leftTitleWithLeftButton | !<img src="https://user-images.githubusercontent.com/81167570/196887319-3711f04d-89d1-4cf8-8841-ab844cb818ae.jpeg" width=200> |
| leftTitle |  <img src= "https://user-images.githubusercontent.com/81167570/196887358-0263f73a-9c94-490e-ba22-7667ddf9c7e2.jpeg" width=200> |
| onlyRightButton | <img src="https://user-images.githubusercontent.com/81167570/196887421-90a94803-5107-4da9-8924-ae46fdfc7bfc.jpeg" width=200> |

### 💡 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. -->
closed #46 
