### PR TITLE
[Setting] #61 - 세로모드, 라이트모드 고정

### DIFF
--- a/SOPT-iOS/Projects/Presentation/Sources/PostDetailScene/VC/PostDetailVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostDetailScene/VC/PostDetailVC.swift
@@ -114,6 +114,7 @@ extension PostDetailVC {
             controller.dismissOnPanGesture = false
             controller.slides = images
             controller.enableZoom = true
+            controller.statusBarStyle = .lightContent
         }
     }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
@@ -73,6 +73,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         })
     }
     
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.portrait
+    }
+    
     // MARK: UISceneSession Lifecycle
     
     func application( _ application: UIApplication,

--- a/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -102,7 +102,8 @@ public extension Project {
             "App Transport Security Settings": ["Allow Arbitrary Loads": true],
             "NSAppTransportSecurity": ["NSAllowsArbitraryLoads": true],
             "ITSAppUsesNonExemptEncryption": false,
-            "UIBackgroundModes": ["fetch", "remote-notification"]
+            "UIBackgroundModes": ["fetch", "remote-notification"],
+            "UIUserInterfaceStyle": "Light"
         ]
 }
 


### PR DESCRIPTION
### 🛠 작업 내용
<!-- 작업한 내용을 적어주세요. -->
- 세로모드 고정
  ```
  func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
        return UIInterfaceOrientationMask.portrait
    }
  ```
- 라이트모드 고정
  - info setting에 UIUserInterfaceStyle 추가

### 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- ImageSlideShowViewController에서는 상단바 컬러를 light로 줬습니다

### 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|파일첨부|

### 💡 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. -->
closed #61 
