### PR TITLE
[Feat] #55 - 공지 리스트 뷰 Domain 및 Data Layer 기능 구현

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/PostDetailRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PostDetailRepository.swift
@@ -23,7 +23,7 @@ public class PostDetailRepository {
 
 extension PostDetailRepository: PostDetailRepositoryInterface {
     public func fetchPostDetail(noticeId: Int) -> AnyPublisher<PostDetailModel, Error> {
-        networkService.fetchNotcieDetail(noticeId: noticeId)
+        networkService.fetchNoticeDetail(noticeId: noticeId)
             .compactMap { $0?.toDomain() }
             .eraseToAnyPublisher()
     }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/PostListRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PostListRepository.swift
@@ -47,15 +47,9 @@ extension PostListRepository {
     }
     
     private func makeMokePostListResultEntity(partName: String) -> AnyPublisher<[PostListModel]?, Error> {
-        let mockPostListData = [
-            PostListData(noticeID: 1, title: "31th SOPT OT 공지 - \(partName)", creator: "관리", createdAt: "2022.5.13"),
-            PostListData(noticeID: 2, title: "31th SOPT 1차 행사 공지 - \(partName)", creator: "관리", createdAt: "2022.6.10"),
-            PostListData(noticeID: 4, title: "31th SOPT 앱잼 공지 - \(partName)", creator: "관리", createdAt: "2022.12.1")
-        ]
-        let mockSearch = PostListEntity(notices: mockPostListData)
-        let model = mockSearch.toDomain()
-        return Just(model)
-                    .setFailureType(to: Error.self)
-                    .eraseToAnyPublisher()
+
+        networkService.fetchNoticeList(partName: partName)
+            .compactMap { $0?.toDomain() }
+            .eraseToAnyPublisher()
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/PostListRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PostListRepository.swift
@@ -28,7 +28,7 @@ extension PostListRepository: PostListRepositoryInterface {
     }
     
     public func getPostListResult(partName: String) -> AnyPublisher<[PostListModel]?, Error> {
-        return makeMokePostListResultEntity()
+        return makeMokePostListResultEntity(partName: partName)
     }
 }
 
@@ -46,11 +46,11 @@ extension PostListRepository {
                     .eraseToAnyPublisher()
     }
     
-    private func makeMokePostListResultEntity() -> AnyPublisher<[PostListModel]?, Error> {
+    private func makeMokePostListResultEntity(partName: String) -> AnyPublisher<[PostListModel]?, Error> {
         let mockPostListData = [
-            PostListData(noticeID: 1, title: "31th SOPT OT 공지", creator: "관리", createdAt: "2022.5.13"),
-            PostListData(noticeID: 2, title: "31th SOPT 1차 행사 공지", creator: "관리", createdAt: "2022.6.10"),
-            PostListData(noticeID: 4, title: "31th SOPT 앱잼 공지", creator: "관리", createdAt: "2022.12.1")
+            PostListData(noticeID: 1, title: "31th SOPT OT 공지 - \(partName)", creator: "관리", createdAt: "2022.5.13"),
+            PostListData(noticeID: 2, title: "31th SOPT 1차 행사 공지 - \(partName)", creator: "관리", createdAt: "2022.6.10"),
+            PostListData(noticeID: 4, title: "31th SOPT 앱잼 공지 - \(partName)", creator: "관리", createdAt: "2022.12.1")
         ]
         let mockSearch = PostListEntity(notices: mockPostListData)
         let model = mockSearch.toDomain()

--- a/SOPT-iOS/Projects/Data/Sources/Repository/PostListRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PostListRepository.swift
@@ -26,6 +26,10 @@ extension PostListRepository: PostListRepositoryInterface {
     public func getSearchResult(str: String) -> AnyPublisher<[PostListModel]?, Error> {
         return makeMockSearchResultEntity()
     }
+    
+    public func getPostListResult(partName: String) -> AnyPublisher<[PostListModel]?, Error> {
+        return makeMokePostListResultEntity()
+    }
 }
 
 extension PostListRepository {
@@ -36,6 +40,19 @@ extension PostListRepository {
             PostSearchData(noticeID: 4, title: "3--th SOPT OT 공지", creator: "관리", createdAt: "10.1.1")
         ]
         let mockSearch = PostSearchEntity(notices: mockSearchData)
+        let model = mockSearch.toDomain()
+        return Just(model)
+                    .setFailureType(to: Error.self)
+                    .eraseToAnyPublisher()
+    }
+    
+    private func makeMokePostListResultEntity() -> AnyPublisher<[PostListModel]?, Error> {
+        let mockPostListData = [
+            PostListData(noticeID: 1, title: "31th SOPT OT 공지", creator: "관리", createdAt: "2022.5.13"),
+            PostListData(noticeID: 2, title: "31th SOPT 1차 행사 공지", creator: "관리", createdAt: "2022.6.10"),
+            PostListData(noticeID: 4, title: "31th SOPT 앱잼 공지", creator: "관리", createdAt: "2022.12.1")
+        ]
+        let mockSearch = PostListEntity(notices: mockPostListData)
         let model = mockSearch.toDomain()
         return Just(model)
                     .setFailureType(to: Error.self)

--- a/SOPT-iOS/Projects/Data/Sources/Transform/PostListTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/PostListTransform.swift
@@ -12,11 +12,10 @@ import Domain
 import Network
 
 extension PostListEntity {
-
-    public func toDomain() -> PostListModel {
-        return PostListModel.init(isNew: false,
-                                  title: "-",
-                                  writer: "-",
-                                  date: "-")
+    public func toDomain() -> [PostListModel] {
+        let noticeList = self.notices.map { entity in
+            return PostListModel.init(isNew: false, title: entity.title, writer: entity.creator, date: entity.createdAt)
+        }
+        return noticeList
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/PartCategory.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/PartCategory.swift
@@ -39,4 +39,23 @@ extension PartCategory {
             return "Server"
         }
     }
+    
+    public var upperCasedTitle: String {
+        switch self {
+        case .fullNotice:
+            return "ALL"
+        case .plan:
+            return "PLAN"
+        case .design:
+            return "DESIGN"
+        case .ios:
+            return "iOS"
+        case .android:
+            return "ANDROID"
+        case .web:
+            return "WEB"
+        case .server:
+            return "SERVER"
+        }
+    }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PostListRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PostListRepositoryInterface.swift
@@ -12,4 +12,5 @@ import Network
 
 public protocol PostListRepositoryInterface {
     func getSearchResult(str: String) -> AnyPublisher<[PostListModel]?, Error>
+    func getPostListResult(partName: String) -> AnyPublisher<[PostListModel]?, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/PostListUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/PostListUseCase.swift
@@ -13,7 +13,9 @@ import Network
 
 public protocol PostListUseCase {
     func getSearch(query: String)
+    func getPostList(partName: String)
     var searchList: PassthroughSubject<[PostListModel], Error> { get set }
+    var postList: PassthroughSubject<[PostListModel], Error> { get set }
 }
 
 public class DefaultPostListUseCase {
@@ -21,13 +23,15 @@ public class DefaultPostListUseCase {
     private let repository: PostListRepositoryInterface
     private var cancelBag = CancelBag()
     public var searchList = PassthroughSubject<[PostListModel], Error>()
-  
+    public var postList =  PassthroughSubject<[PostListModel], Error>()
+    
     public init(repository: PostListRepositoryInterface) {
         self.repository = repository
     }
 }
 
 extension DefaultPostListUseCase: PostListUseCase {
+    
     public func getSearch(query: String) {
         repository.getSearchResult(str: query)
             .sink(receiveCompletion: { event in
@@ -36,6 +40,17 @@ extension DefaultPostListUseCase: PostListUseCase {
                 guard let entity = entity else { return }
                 self.searchList.send(entity)
             })
+            .store(in: cancelBag)
+    }
+    
+    public func getPostList(partName: String) {
+        repository.getPostListResult(partName: partName)
+            .sink { event in
+                print("completion: \(event)")
+            } receiveValue: { entity in
+                guard let entity = entity else { return }
+                self.postList.send(entity)
+            }
             .store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/NoticeAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/NoticeAPI.swift
@@ -13,7 +13,8 @@ import Alamofire
 import Moya
 
 public enum NoticeAPI {
-    case fetchNotcieDetail(noticeId: Int)
+    case fetchNoticeDetail(noticeId: Int)
+    case fetchNoticeList(partName: String)
 }
 
 extension NoticeAPI: BaseAPI {
@@ -40,15 +41,17 @@ extension NoticeAPI: BaseAPI {
     private var bodyParameters: Parameters? {
         var params: Parameters = [:]
         switch self {
-        case .fetchNotcieDetail(let noticeId):
+        case .fetchNoticeDetail(let noticeId):
             params["notice_id"] = noticeId
+        case .fetchNoticeList(let partName):
+            params["part"] = partName
         }
         return params
     }
     
-    private var parameterEncoding : ParameterEncoding{
+    private var parameterEncoding: ParameterEncoding {
         switch self {
-        case .fetchNotcieDetail:
+        case .fetchNoticeDetail:
             return URLEncoding.init(destination: .queryString, arrayEncoding: .noBrackets, boolEncoding: .literal)
         default :
             return JSONEncoding.default
@@ -64,7 +67,7 @@ extension NoticeAPI: BaseAPI {
     
     public var sampleData: Data {
         switch self {
-        case .fetchNotcieDetail(let noticeId):
+        case .fetchNoticeDetail(let noticeId):
             let entity = PostDetailEntity.init(noticeID: noticeId,
                                                title: "샘플 제목",
                                                creator: "이준호",
@@ -74,6 +77,19 @@ extension NoticeAPI: BaseAPI {
                                                part: "iOS",
                                                scope: "iOS")
             if let data = try? JSONEncoder().encode(entity) {
+                return data
+            } else {
+                return Data()
+            }
+        case .fetchNoticeList(let partName):
+            let mockPostListData = [
+                PostListData(noticeID: 1, title: "31th SOPT OT 공지 - \(partName)", creator: "관리", createdAt: "2022.5.13"),
+                PostListData(noticeID: 2, title: "31th SOPT 1차 행사 공지 - \(partName)", creator: "관리", createdAt: "2022.6.10"),
+                PostListData(noticeID: 4, title: "31th SOPT 앱잼 공지 - \(partName)", creator: "관리", createdAt: "2022.12.1")
+            ]
+            let mockList = PostListEntity(notices: mockPostListData)
+            
+            if let data = try? JSONEncoder().encode(mockList) {
                 return data
             } else {
                 return Data()

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/PostListEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/PostListEntity.swift
@@ -8,9 +8,31 @@
 
 import Foundation
 
+// MARK: - PostListEntity
+
 public struct PostListEntity: Codable {
+    public let notices: [PostListData]
     
-    public init() {
-        
+    public init(notices: [PostListData]) {
+        self.notices = notices
+    }
+}
+
+// MARK: - Notice
+
+public struct PostListData: Codable {
+    public let noticeID: Int
+    public let title, creator, createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case noticeID = "notice_id"
+        case title, creator, createdAt
+    }
+    
+    public init(noticeID: Int, title: String, creator: String, createdAt: String) {
+        self.noticeID = noticeID
+        self.title = title
+        self.creator = creator
+        self.createdAt = createdAt
     }
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/NoticeService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/NoticeService.swift
@@ -15,11 +15,18 @@ import Moya
 public typealias DefaultNoticeService = BaseService<NoticeAPI>
 
 public protocol NoticeService {
-    func fetchNotcieDetail(noticeId: Int) -> AnyPublisher<PostDetailEntity?, Error>
+    func fetchNoticeDetail(noticeId: Int) -> AnyPublisher<PostDetailEntity?, Error>
+    func fetchNoticeList(partName: String) ->
+        AnyPublisher<PostListEntity?, Error>
 }
 
 extension DefaultNoticeService: NoticeService {
-    public func fetchNotcieDetail(noticeId: Int) -> AnyPublisher<PostDetailEntity?, Error> {
-        return test.requestObjectInCombine(.fetchNotcieDetail(noticeId: noticeId))
+    public func fetchNoticeDetail(noticeId: Int) -> AnyPublisher<PostDetailEntity?, Error> {
+        return test.requestObjectInCombine(.fetchNoticeDetail(noticeId: noticeId))
+    }
+    
+    public func fetchNoticeList(partName: String) ->
+    AnyPublisher<PostListEntity?, Error> {
+        return test.requestObjectInCombine(.fetchNoticeList(partName: partName))
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/VC/PostListVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/VC/PostListVC.swift
@@ -217,7 +217,6 @@ extension PostListVC {
                     self.setSearchEmpty(false)
                     self.applySnapshot()
                 }
-                
             })
             .store(in: cancelBag)
     }

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/VC/PostListVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/VC/PostListVC.swift
@@ -23,6 +23,7 @@ public class PostListVC: UIViewController {
     public var viewModel: PostListViewModel!
     private var cancelBag = CancelBag()
     private var textChanged = PassthroughSubject<String?, Error>()
+    private var selectedPartIndex = PassthroughSubject<Int, Error>()
     
     public var factory: ModuleFactoryInterface!
     
@@ -81,6 +82,7 @@ public class PostListVC: UIViewController {
         self.setRegister()
         self.setDelegate()
         self.setTableView()
+        self.bindViewPager()
         self.bindViewModels()
     }
 }
@@ -184,6 +186,12 @@ extension PostListVC {
 // MARK: - Methods
 
 extension PostListVC {
+    private func bindViewPager() {
+        postListViewPager.$selectedTabIndex.sink {
+            print($0)
+        }.store(in: cancelBag)
+    }
+    
     private func bindViewModels() {
         let input = PostListViewModel.Input(textChanged: textChanged.eraseToAnyPublisher())
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/VC/PostListVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/VC/PostListVC.swift
@@ -27,7 +27,6 @@ public class PostListVC: UIViewController {
     private var selectedPartIndex = PassthroughSubject<Int, Error>()
     
     private var searchResultList: [PostListModel] = []
-    let partList = ["전체", "기획", "디자인", "iOS", "Android", "Server", "Web"]
     
     // MARK: - UI Components
     
@@ -61,8 +60,8 @@ public class PostListVC: UIViewController {
     private lazy var postListViewPager: ViewPager = {
         let viewPager = ViewPager(tabSizeConfiguration: .fixed(width: 72, height: 32))
         
-        let tabs = partList.map { TabItemView(title: $0) }
-        let pages = partList.map { _ in PostListPageView() }
+        let tabs = PartCategory.allCases.map { TabItemView(title: $0.title) }
+        let pages = PartCategory.allCases.map { _ in PostListPageView() }
         
         viewPager.tabbedView.tabs = tabs
         

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/ViewModel/PostListViewModel.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/ViewModel/PostListViewModel.swift
@@ -13,8 +13,6 @@ import Domain
 
 public class PostListViewModel: ViewModelType {
     
-    // 파트 리스트 임시로 ViewModel이 소유 (수정 예정)
-    let partList: [String] = ["ALL", "PLAN", "DESIGN", "iOS", "ANDROID", "SERVER", "WEB"]
     var partIndex: Int = 0
     private let useCase: PostListUseCase
     private var cancelBag = CancelBag()
@@ -51,7 +49,7 @@ extension PostListViewModel {
             }, receiveValue: { [weak self] idx in
                 guard let self = self else { return }
                 self.partIndex = idx
-                self.useCase.getPostList(partName: self.partList[idx])
+                self.useCase.getPostList(partName: PartCategory.allCases[idx].upperCasedTitle)
             })
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/PostListPageView.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/PostListPageView.swift
@@ -90,7 +90,7 @@ extension PostListPageView {
         var snapshot = NSDiffableDataSourceSnapshot<Int, PostListModel>()
         snapshot.appendSections([0])
         snapshot.appendItems(postList)
-        self.diffableDataSource.apply(snapshot)
+        self.diffableDataSource.apply(snapshot, animatingDifferences: true)
     }
     
     func setData(data: [PostListModel]) {

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/PostListPageView.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/PostListPageView.swift
@@ -8,11 +8,14 @@
 
 import UIKit
 
+import Domain
+
 final class PostListPageView: UIView {
     
     // MARK: - Properties
     
-    lazy var dataSource: UITableViewDiffableDataSource<Int, UUID>! = nil
+    lazy var diffableDataSource: UITableViewDiffableDataSource<Int, PostListModel>! = nil
+    private var postList: [PostListModel] = []
 
     // MARK: - UI Components
     
@@ -71,20 +74,28 @@ extension PostListPageView {
 
 extension PostListPageView {
     private func setDataSource() {
-        self.dataSource = UITableViewDiffableDataSource(tableView: postListTableView, cellProvider: { tableView, indexPath, itemIdentifier in
-            let cell = tableView.dequeueReusableCell(withIdentifier: PostListTableViewCell.className, for: indexPath)
+        self.diffableDataSource = UITableViewDiffableDataSource<Int, PostListModel>(tableView: postListTableView, cellProvider: { tableView, indexPath, itemIdentifier in
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: PostListTableViewCell.className, for: indexPath)
+                    as? PostListTableViewCell else { return UITableViewCell() }
+            let data = self.postList[indexPath.row]
             cell.selectionStyle = .none
+            cell.initCell(isNew: data.isNew, title: data.title, writer: data.writer, date: data.date)
             return cell
         })
         
-        self.postListTableView.dataSource = self.dataSource
+        self.postListTableView.dataSource = self.diffableDataSource
     }
     
     func applySnapshot() {
-        var snapshot = NSDiffableDataSourceSnapshot<Int, UUID>()
+        var snapshot = NSDiffableDataSourceSnapshot<Int, PostListModel>()
         snapshot.appendSections([0])
-        snapshot.appendItems([UUID(), UUID(), UUID(), UUID()])
-        self.dataSource.apply(snapshot)
+        snapshot.appendItems(postList)
+        self.diffableDataSource.apply(snapshot)
+    }
+    
+    func setData(data: [PostListModel]) {
+        self.postList = data
+        applySnapshot()
     }
 }
 

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/TabItemView.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/TabItemView.swift
@@ -26,12 +26,6 @@ final class TabItemView: UIView {
         return label
     }()
     
-    private let dividerView: UIView = {
-        let view = UIView()
-        view.backgroundColor = DSKitAsset.Colors.gray300.color
-        return view
-    }()
-    
     private lazy var borderView: UIView = {
         let view = UIView()
         view.backgroundColor = DSKitAsset.Colors.blue500.color
@@ -59,15 +53,10 @@ final class TabItemView: UIView {
     }
     
     private func setLayout() {
-        self.addSubviews(titleLabel, dividerView)
+        self.addSubviews(titleLabel)
         
         titleLabel.snp.makeConstraints { make in
             make.center.equalToSuperview()
-        }
-        
-        dividerView.snp.makeConstraints { make in
-            make.leading.bottom.trailing.equalToSuperview()
-            make.height.equalTo(1)
         }
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/TabItemView.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/TabItemView.swift
@@ -49,7 +49,7 @@ final class TabItemView: UIView {
     // MARK: - UI & Layout
     
     private func setUI() {
-        self.backgroundColor = .white
+        self.backgroundColor = .clear
     }
     
     private func setLayout() {

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/CollectionView/TabbedView.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/CollectionView/TabbedView.swift
@@ -50,7 +50,7 @@ final class TabbedView: UIView {
             frame: .zero,
             collectionViewLayout: layout
         )
-        collectionView.backgroundColor = .white
+        collectionView.backgroundColor = .clear
         collectionView.register(TabCollectionViewCell.self, forCellWithReuseIdentifier: TabCollectionViewCell.className)
         collectionView.dataSource = self
         collectionView.delegate = self
@@ -66,7 +66,7 @@ final class TabbedView: UIView {
         self.sizeConfiguration = sizeConfiguration
         self.tabs = tabs
         super.init(frame: .zero)
-        
+        self.setUI()
         self.setLayout()
     }
     
@@ -75,6 +75,9 @@ final class TabbedView: UIView {
     }
     
     // MARK: - UI & Layout
+    private func setUI() {
+        self.backgroundColor = .clear
+    }
     
     private func setLayout() {
         self.addSubview(collectionView)

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/CollectionView/TabbedView.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/CollectionView/TabbedView.swift
@@ -150,7 +150,7 @@ extension TabbedView: UICollectionViewDataSource {
 extension TabbedView: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.moveToTab(at: indexPath.item)
         selectedTabIndex.send(indexPath.item)
+        self.moveToTab(at: indexPath.item)
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/CollectionViewCell/TabCollectionViewCell.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/CollectionViewCell/TabCollectionViewCell.swift
@@ -35,6 +35,10 @@ final class TabCollectionViewCell: UICollectionViewCell {
     
     // MARK: - UI & Layout
     
+    private func setUI() {
+        self.contentView.backgroundColor = .clear
+    }
+    
     private func setLayout() {
         guard let view = view else { return }
         

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/ViewPager.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/ViewPager.swift
@@ -67,7 +67,6 @@ extension ViewPager {
             make.height.equalTo(sizeConfiguration.height)
         }
         
-        self.sendSubviewToBack(dividerView)
         dividerView.snp.makeConstraints { make in
             make.height.equalTo(1)
             make.top.equalTo(tabbedView.snp.bottom).inset(1)

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/ViewPager.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/ViewPager.swift
@@ -66,7 +66,7 @@ extension ViewPager {
             make.leading.trailing.equalToSuperview().inset(16)
             make.height.equalTo(sizeConfiguration.height)
         }
-        
+        self.sendSubviewToBack(dividerView)
         dividerView.snp.makeConstraints { make in
             make.height.equalTo(1)
             make.top.equalTo(tabbedView.snp.bottom).inset(1)

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/ViewPager.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/ViewPager.swift
@@ -17,6 +17,7 @@ class ViewPager: UIView {
     // MARK: - Properties
     
     private var cancelBag = CancelBag()
+    @Published var selectedTabIndex = 0
     
     public let sizeConfiguration: TabbedView.SizeConfiguration
     
@@ -84,6 +85,7 @@ extension ViewPager {
     private func bind() {
         tabbedView.selectedTabIndex.sink {
             self.pagedView.moveToPage(at: $0)
+            self.selectedTabIndex = $0
         }.store(in: self.cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/ViewPager.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/PostListScene/Views/ViewPager/ViewPager.swift
@@ -10,6 +10,7 @@ import UIKit
 import Combine
 
 import Core
+import Domain
 import DSKit
 
 class ViewPager: UIView {
@@ -51,8 +52,11 @@ class ViewPager: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: - UI & Layout
+}
+
+// MARK: - Methods
+
+extension ViewPager {
     
     private func setLayout() {
         self.addSubviews(tabbedView, dividerView, pagedView)
@@ -76,8 +80,12 @@ class ViewPager: UIView {
             make.top.equalTo(tabbedView.snp.bottom)
         }
     }
+    
+    func setData(partIndex: Int, data: [PostListModel]) {
+        guard let page = pagedView.pages[partIndex] as? PostListPageView else { return }
+        page.setData(data: data)
+    }
 }
-
 // MARK: - Bind
 
 extension ViewPager {

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: scene.coordinateSpace.bounds)
         window?.windowScene = scene
-        let rootViewController = ModuleFactory.shared.makeSplashVC()
+        let rootViewController = ModuleFactory.shared.makePostListVC()
         window?.rootViewController = UINavigationController(rootViewController: rootViewController)
         window?.makeKeyAndVisible()
     }


### PR DESCRIPTION
### 🛠 작업 내용
<!-- 작업한 내용을 적어주세요. -->
- 공지 리스트 뷰 서버 통신 구현
- PostListEntity, Transform 구현
- NoticeAPI, NoticeService에 fetchNoticeList 추가
- PostListRepository와 PostListUseCase에 getPostList 추가
- PostListVC와 ViewModel 바인딩
- 공지 뷰페이저와 PostListVC 바인딩

### 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 지금 구현한 방식에서는 공지 리스트 뷰에서 파트 카테고리를 사용자가 클릭하면 해당 클릭이 발생할 때마다 서버로 파트 이름을 넘기고 해당 파트에 맞는 공지 리스트를 받아오는 방식입니다. (refresh controll이 없는 시점에서는 이게 그나마 괜찮은 방식이라고 생각했습니다.)  => 그럴 일은 없으면 좋겠지만 사용자가 파트 카테고리를 연속해서 누르면 서버 요청이 계속 발생합니다. 혹시 공지 리스트를 받아오는 시점에 대해서 다른 좋은 아이디어가 있다면 피드백 주세요!!!

### 📸 스크린샷

https://user-images.githubusercontent.com/77267404/198812341-11c0583b-53f1-45d4-8db1-34e2d828d93c.mp4


### 💡 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. -->
closed : #55 
