### PR TITLE
[Feat] #54 - 회원가입 뷰 인증 이메일 발송 Domain 및 Data Layer 기능 구현

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/AuthSignUpRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/AuthSignUpRepository.swift
@@ -30,7 +30,7 @@ extension AuthSignUpRepository: AuthSignUpRepositoryInterface {
 
 extension AuthSignUpRepository {
     private func makeMockAuthEmailEntity() -> AnyPublisher<AuthSignUpModel?, Error> {
-        let mockAuthEmail = AuthSignUpEntity(userId: 12345)
+        let mockAuthEmail = AuthSignUpEntity(userId: 12345, message: nil)
         let model = mockAuthEmail.toDomain()
         return Just(model)
             .setFailureType(to: Error.self)

--- a/SOPT-iOS/Projects/Data/Sources/Repository/AuthSignUpRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/AuthSignUpRepository.swift
@@ -24,16 +24,14 @@ public class AuthSignUpRepository {
 
 extension AuthSignUpRepository: AuthSignUpRepositoryInterface {
     public func postAuthEmail(email: String) -> AnyPublisher<AuthSignUpModel?, Error> {
-        return makeMockAuthEmailEntity()
+        return makeMockAuthEmailEntity(email: email)
     }
 }
 
 extension AuthSignUpRepository {
-    private func makeMockAuthEmailEntity() -> AnyPublisher<AuthSignUpModel?, Error> {
-        let mockAuthEmail = AuthSignUpEntity(userId: 12345, message: nil)
-        let model = mockAuthEmail.toDomain()
-        return Just(model)
-            .setFailureType(to: Error.self)
+    private func makeMockAuthEmailEntity(email: String) -> AnyPublisher<AuthSignUpModel?, Error> {
+        networkService.postAuthEmail(email: email, token: "dummy-token")
+            .compactMap { $0?.toDomain() }
             .eraseToAnyPublisher()
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/AuthSignUpRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/AuthSignUpRepository.swift
@@ -24,12 +24,12 @@ public class AuthSignUpRepository {
 
 extension AuthSignUpRepository: AuthSignUpRepositoryInterface {
     public func postAuthEmail(email: String) -> AnyPublisher<AuthSignUpModel?, Error> {
-        return makeMockAuthEmailEntity(email: email)
+        return makeAuthEmailEntity(email: email)
     }
 }
 
 extension AuthSignUpRepository {
-    private func makeMockAuthEmailEntity(email: String) -> AnyPublisher<AuthSignUpModel?, Error> {
+    private func makeAuthEmailEntity(email: String) -> AnyPublisher<AuthSignUpModel?, Error> {
         networkService.postAuthEmail(email: email, token: "dummy-token")
             .compactMap { $0?.toDomain() }
             .eraseToAnyPublisher()

--- a/SOPT-iOS/Projects/Data/Sources/Repository/AuthSignUpRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/AuthSignUpRepository.swift
@@ -1,6 +1,6 @@
 //
 //  AuthSignUpRepository.swift
-//  Presentation
+//  Data
 //
 //  Created by devxsby on 2022/10/23.
 //  Copyright © 2022 SOPT-iOS. All rights reserved.
@@ -23,5 +23,17 @@ public class AuthSignUpRepository {
 }
 
 extension AuthSignUpRepository: AuthSignUpRepositoryInterface {
-    
+    public func postAuthEmail(email: String) -> AnyPublisher<AuthSignUpModel?, Error> {
+        return makeMockAuthEmailEntity()
+    }
+}
+
+extension AuthSignUpRepository {
+    private func makeMockAuthEmailEntity() -> AnyPublisher<AuthSignUpModel?, Error> {
+        let mockAuthEmail = AuthSignUpEntity(userId: 12345)
+        let model = mockAuthEmail.toDomain()
+        return Just(model)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/AuthSignUpTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/AuthSignUpTransform.swift
@@ -14,6 +14,6 @@ import Network
 extension AuthSignUpEntity {
 
     public func toDomain() -> AuthSignUpModel {
-        return AuthSignUpModel.init(userId: self.userId)
+        return AuthSignUpModel.init(userId: self.userId, message: self.message)
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/AuthSignUpTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/AuthSignUpTransform.swift
@@ -14,6 +14,6 @@ import Network
 extension AuthSignUpEntity {
 
     public func toDomain() -> AuthSignUpModel {
-        return AuthSignUpModel.init()
+        return AuthSignUpModel.init(userId: self.userID)
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/AuthSignUpTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/AuthSignUpTransform.swift
@@ -14,6 +14,6 @@ import Network
 extension AuthSignUpEntity {
 
     public func toDomain() -> AuthSignUpModel {
-        return AuthSignUpModel.init(userId: self.userID)
+        return AuthSignUpModel.init(userId: self.userId)
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/AuthSignUpModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/AuthSignUpModel.swift
@@ -1,6 +1,6 @@
 //
 //  AuthSignUpModel.swift
-//  Presentation
+//  Domain
 //
 //  Created by devxsby on 2022/10/23.
 //  Copyright © 2022 SOPT-iOS. All rights reserved.
@@ -8,9 +8,10 @@
 
 import Foundation
 
-public struct AuthSignUpModel {
+public struct AuthSignUpModel: Hashable {
+    public let userId: Int
 
-    public init() {
-        
+    public init(userId: Int) {
+        self.userId = userId
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/AuthSignUpModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/AuthSignUpModel.swift
@@ -9,9 +9,11 @@
 import Foundation
 
 public struct AuthSignUpModel: Hashable {
-    public let userId: Int
+    public let userId: Int?
+    public let message: String?
 
-    public init(userId: Int) {
+    public init(userId: Int?, message: String?) {
         self.userId = userId
+        self.message = message
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AuthSignUpRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AuthSignUpRepositoryInterface.swift
@@ -9,5 +9,5 @@
 import Combine
 
 public protocol AuthSignUpRepositoryInterface {
-  
+    func postAuthEmail(email: String) -> AnyPublisher<AuthSignUpModel?, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/AuthSignUpUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/AuthSignUpUseCase.swift
@@ -13,6 +13,7 @@ import Network
 
 public protocol AuthSignUpUseCase {
     func postAuthEmail(email: String)
+    var authSignUpModel: PassthroughSubject<AuthSignUpModel, Error> { get set }
 }
 
 public class DefaultAuthSignUpUseCase {

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/AuthSignUpUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/AuthSignUpUseCase.swift
@@ -1,6 +1,6 @@
 //
 //  AuthSignUpUseCase.swift
-//  Presentation
+//  Domain
 //
 //  Created by devxsby on 2022/10/23.
 //  Copyright © 2022 SOPT-iOS. All rights reserved.
@@ -9,15 +9,17 @@
 import Combine
 
 import Core
+import Network
 
 public protocol AuthSignUpUseCase {
-
+    func postAuthEmail(email: String)
 }
 
 public class DefaultAuthSignUpUseCase {
   
     private let repository: AuthSignUpRepositoryInterface
     private var cancelBag = CancelBag()
+    public var authSignUpModel = PassthroughSubject<AuthSignUpModel, Error>()
   
     public init(repository: AuthSignUpRepositoryInterface) {
         self.repository = repository
@@ -25,5 +27,14 @@ public class DefaultAuthSignUpUseCase {
 }
 
 extension DefaultAuthSignUpUseCase: AuthSignUpUseCase {
-  
+    public func postAuthEmail(email: String) {
+        repository.postAuthEmail(email: email)
+            .sink { event in
+                print("completion: \(event)")
+            } receiveValue: { entity in
+                guard let entity = entity else { return }
+                self.authSignUpModel.send(entity)
+            }
+            .store(in: cancelBag)
+    }
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
@@ -12,7 +12,7 @@ import Alamofire
 import Moya
 
 public enum AuthAPI {
-    case sample(provider: String)
+    case postAuthEmail(email: String, token: String)
 }
 
 extension AuthAPI: BaseAPI {
@@ -22,15 +22,15 @@ extension AuthAPI: BaseAPI {
     // MARK: - Path
     public var path: String {
         switch self {
-        case .sample:
-            return ""
+        case .postAuthEmail:
+            return "auth/send/email"
         }
     }
     
     // MARK: - Method
     public var method: Moya.Method {
         switch self {
-        case .sample:
+        case .postAuthEmail:
             return .post
         }
     }
@@ -39,27 +39,46 @@ extension AuthAPI: BaseAPI {
     private var bodyParameters: Parameters? {
         var params: Parameters = [:]
         switch self {
-        case .sample(let provider):
-            params["platform"] = provider
+        case .postAuthEmail(let email, let token):
+            params["email"] = email
+            params["clientToken"] = token
+            params["osType"] = "iOS"
         }
         return params
     }
     
-    private var parameterEncoding : ParameterEncoding{
+    private var parameterEncoding: ParameterEncoding {
         switch self {
-        case .sample:
+        case .postAuthEmail:
             return URLEncoding.init(destination: .queryString, arrayEncoding: .noBrackets, boolEncoding: .literal)
-        default :
+        default:
             return JSONEncoding.default
         }
     }
     
     public var task: Task {
         switch self {
-        case .sample:
+        case .postAuthEmail:
             return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
         default:
             return .requestPlain
+        }
+    }
+}
+
+extension AuthAPI {
+    public var sampleData: Data {
+        switch self {
+        case .postAuthEmail:
+            let mockValidAuthEntity = AuthSignUpEntity(userId: 12345, message: nil)
+            let mockInvalidAuthEntity = AuthSignUpEntity(userId: nil, message: "등록되지 않은 메일입니다.")
+            let sampleArray = [mockValidAuthEntity, mockInvalidAuthEntity]
+            
+            if let data = try? JSONEncoder().encode(sampleArray.randomElement()!) {
+                return data
+            } else {
+                return Data()
+            }
         }
     }
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/AuthSignUpEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/AuthSignUpEntity.swift
@@ -9,13 +9,16 @@
 import Foundation
 
 public struct AuthSignUpEntity: Codable {
-    public let userId: Int
+    public let userId: Int?
+    public let message: String?
     
     enum CodingKeys: String, CodingKey {
         case userId = "user_id"
+        case message
     }
     
-    public init(userId: Int) {
+    public init(userId: Int?, message: String?) {
         self.userId = userId
+        self.message = message
     }
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/AuthSignUpEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/AuthSignUpEntity.swift
@@ -9,9 +9,13 @@
 import Foundation
 
 public struct AuthSignUpEntity: Codable {
-    public let userID: Int
+    public let userId: Int
     
     enum CodingKeys: String, CodingKey {
-        case userID = "user_id"
+        case userId = "user_id"
+    }
+    
+    public init(userId: Int) {
+        self.userId = userId
     }
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/AuthSignUpEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/AuthSignUpEntity.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
-public struct AuthSignUpEntity {
+public struct AuthSignUpEntity: Codable {
+    public let userID: String
     
+    enum CodingKeys: String, CodingKey {
+        case userID = "user_id"
+    }
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/AuthSignUpEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/AuthSignUpEntity.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct AuthSignUpEntity: Codable {
-    public let userID: String
+    public let userID: Int
     
     enum CodingKeys: String, CodingKey {
         case userID = "user_id"

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/AuthService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/AuthService.swift
@@ -15,9 +15,11 @@ import Moya
 public typealias DefaultAuthService = BaseService<AuthAPI>
 
 public protocol AuthService {
-    
+    func postAuthEmail(email: String, token: String) -> AnyPublisher<AuthSignUpEntity?, Error>
 }
 
 extension DefaultAuthService: AuthService {
-    
+    public func postAuthEmail(email: String, token: String) -> AnyPublisher<AuthSignUpEntity?, Error> {
+        return test.requestObjectInCombine(.postAuthEmail(email: email, token: token))
+    }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/AuthScene/VC/AuthCompleteVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/AuthScene/VC/AuthCompleteVC.swift
@@ -77,6 +77,7 @@ extension AuthCompleteVC {
 extension AuthCompleteVC {
     
     @objc private func startButtonDidTap() {
-        print("start Button Did Tap")
+        let authPushAlarmVC = factory.makeAuthPushAlarmVC()
+        self.navigationController?.pushViewController(authPushAlarmVC, animated: true)
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/AuthScene/VC/AuthSignUpVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/AuthScene/VC/AuthSignUpVC.swift
@@ -147,6 +147,22 @@ extension AuthSignUpVC {
     private func bindViewModels() {
         let input = AuthSignUpViewModel.Input(verifyButtonTapped: verifyButtonTapped, textChanged: textChanged)
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+        
+        output.isValidUser.sink { event in
+            print("AuthSignUpVC - completion: \(event)")
+        } receiveValue: { value in
+            self.captionLabel.isHidden = value
+            if value {
+                let authWaitingVC = self.factory.makeAuthWaitingVC()
+                self.navigationController?.pushViewController(authWaitingVC, animated: true)
+            }
+        }.store(in: self.cancelBag)
+        
+        output.message.sink { event in
+            print("AuthSignUpVC - completion: \(event)")
+        } receiveValue: { value in
+            self.captionLabel.text = value
+        }.store(in: self.cancelBag)
     }
     
     @objc private func textFieldChanged() {

--- a/SOPT-iOS/Projects/Presentation/Sources/AuthScene/VC/AuthSignUpVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/AuthScene/VC/AuthSignUpVC.swift
@@ -28,6 +28,7 @@ public class AuthSignUpVC: UIViewController {
     
     private lazy var naviBar = CustomNavigationBar(self, type: .onlyRightButton)
         .setRightButtonTitle("인증하기")
+        .changeRightButtonState(isEnabled: false)
         .rightButtonAction { 
             self.verifyButtonTapped.send()
         }
@@ -77,6 +78,7 @@ public class AuthSignUpVC: UIViewController {
         $0.text = "등록되지 않은 메일입니다."
         $0.textColor = DSKitAsset.Colors.error.color
         $0.setTypoStyle(.caption)
+        $0.isHidden = true
     }
   
     // MARK: - View Life Cycle
@@ -167,9 +169,11 @@ extension AuthSignUpVC {
     
     @objc private func textFieldChanged() {
         self.textChanged.send(emailTextField.text)
+        self.naviBar = self.naviBar.changeRightButtonState(isEnabled: emailTextField.hasText)
     }
     
     @objc private func guestButtonDidTap() {
-        print("guest Button Did Tap")
+        let postListVC = self.factory.makePostListVC()
+        self.navigationController?.pushViewController(postListVC, animated: true)
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/AuthScene/VC/AuthSignUpVC.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/AuthScene/VC/AuthSignUpVC.swift
@@ -88,6 +88,7 @@ public class AuthSignUpVC: UIViewController {
         self.bindViewModels()
         self.setUI()
         self.setLayout()
+        self.disablePopGesture()
     }
 }
 
@@ -175,5 +176,8 @@ extension AuthSignUpVC {
     @objc private func guestButtonDidTap() {
         let postListVC = self.factory.makePostListVC()
         self.navigationController?.pushViewController(postListVC, animated: true)
+    }
+    
+    private func disablePopGesture() { self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/AuthScene/ViewModel/AuthSignUpViewModel.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/AuthScene/ViewModel/AuthSignUpViewModel.swift
@@ -27,7 +27,8 @@ public class AuthSignUpViewModel: ViewModelType {
     // MARK: - Outputs
     
     public struct Output {
-        var authSignUpModel = PassthroughSubject<AuthSignUpModel, Error>()
+        var isValidUser = PassthroughSubject<Bool, Error>()
+        var message = PassthroughSubject<String?, Error>()
     }
     
     // MARK: - init
@@ -55,7 +56,6 @@ extension AuthSignUpViewModel {
                 print("AuthSignUpViewModel - completion: \(event)")
             } receiveValue: { value in
                 self.emailText = value
-                print(value)
             }.store(in: self.cancelBag)
         
         return output
@@ -65,7 +65,12 @@ extension AuthSignUpViewModel {
         useCase.authSignUpModel.sink { event in
             print("AuthSignUpViewModel - completion: \(event)")
         } receiveValue: { value in
-            output.authSignUpModel.send(value)
+            if let _ = value.userId {
+                output.isValidUser.send(true)
+            } else {
+                output.isValidUser.send(false)
+                output.message.send(value.message)
+            }
         }.store(in: self.cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/AuthScene/ViewModel/AuthSignUpViewModel.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/AuthScene/ViewModel/AuthSignUpViewModel.swift
@@ -20,7 +20,7 @@ public class AuthSignUpViewModel: ViewModelType {
     // MARK: - Inputs
     
     public struct Input {
-        let verifyButtonTapped: PassthroughSubject<Void, Error>
+        let verifyButtonTapped: Driver<Void>
         let textChanged: PassthroughSubject<String?, Error>
     }
     
@@ -44,11 +44,9 @@ extension AuthSignUpViewModel {
         self.bindOutput(output: output, cancelBag: cancelBag)
         
         input.verifyButtonTapped
-            .sink { event in
-                print("AuthSignUpViewModel - completion: \(event)")
-            } receiveValue: { _ in
+            .sink(receiveValue: { () in
                 self.useCase.postAuthEmail(email: self.emailText)
-            }.store(in: self.cancelBag)
+            }).store(in: self.cancelBag)
         
         input.textChanged
             .compactMap { $0 }

--- a/SOPT-iOS/Projects/Presentation/Sources/AuthScene/ViewModel/AuthSignUpViewModel.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/AuthScene/ViewModel/AuthSignUpViewModel.swift
@@ -27,7 +27,7 @@ public class AuthSignUpViewModel: ViewModelType {
     // MARK: - Outputs
     
     public struct Output {
-    
+        var authSignUpModel = PassthroughSubject<AuthSignUpModel, Error>()
     }
     
     // MARK: - init
@@ -50,7 +50,7 @@ extension AuthSignUpViewModel {
             }.store(in: self.cancelBag)
         
         input.textChanged
-            .compactMap{ $0 }
+            .compactMap { $0 }
             .sink { event in
                 print("AuthSignUpViewModel - completion: \(event)")
             } receiveValue: { value in
@@ -62,6 +62,10 @@ extension AuthSignUpViewModel {
     }
   
     private func bindOutput(output: Output, cancelBag: CancelBag) {
-    
+        useCase.authSignUpModel.sink { event in
+            print("AuthSignUpViewModel - completion: \(event)")
+        } receiveValue: { value in
+            output.authSignUpModel.send(value)
+        }.store(in: self.cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/AuthScene/ViewModel/AuthSignUpViewModel.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/AuthScene/ViewModel/AuthSignUpViewModel.swift
@@ -15,11 +15,13 @@ public class AuthSignUpViewModel: ViewModelType {
 
     private let useCase: AuthSignUpUseCase
     private var cancelBag = CancelBag()
+    private var emailText = ""
   
     // MARK: - Inputs
     
     public struct Input {
-    
+        let verifyButtonTapped: PassthroughSubject<Void, Error>
+        let textChanged: PassthroughSubject<String?, Error>
     }
     
     // MARK: - Outputs
@@ -39,8 +41,23 @@ extension AuthSignUpViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
-        // input,output 상관관계 작성
-    
+        
+        input.verifyButtonTapped
+            .sink { event in
+                print("AuthSignUpViewModel - completion: \(event)")
+            } receiveValue: { _ in
+                self.useCase.postAuthEmail(email: self.emailText)
+            }.store(in: self.cancelBag)
+        
+        input.textChanged
+            .compactMap{ $0 }
+            .sink { event in
+                print("AuthSignUpViewModel - completion: \(event)")
+            } receiveValue: { value in
+                self.emailText = value
+                print(value)
+            }.store(in: self.cancelBag)
+        
         return output
     }
   

--- a/SOPT-iOS/Projects/Presentation/Sources/Components/CustomNavigationBar.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/Components/CustomNavigationBar.swift
@@ -70,6 +70,11 @@ extension CustomNavigationBar {
         self.leftButton.addTarget(self, action: #selector(popToPreviousVC), for: .touchUpInside)
     }
     
+    public func changeRightButtonState(isEnabled: Bool) -> Self {
+        self.rightButton.isEnabled = isEnabled
+        return self
+    }
+    
     @discardableResult
     func setTitle(_ title: String) -> Self {
         self.titleLabel.text = title
@@ -196,10 +201,5 @@ extension CustomNavigationBar {
             make.trailing.equalToSuperview().inset(16)
             make.height.equalTo(40)
         }
-    }
-    
-    public func changeRightButtonState(isEnabled: Bool) -> Self {
-        self.rightButton.isEnabled = isEnabled
-        return self
     }
 }

--- a/SOPT-iOS/Projects/Presentation/Sources/Components/CustomNavigationBar.swift
+++ b/SOPT-iOS/Projects/Presentation/Sources/Components/CustomNavigationBar.swift
@@ -131,6 +131,7 @@ extension CustomNavigationBar {
             otherRightButton.setImage(UIImage(asset: DSKitAsset.Assets.icSearch), for: .normal)
         case .leftTitleWithLeftButton, .onlyRightButton:
             rightButton.setTitleColor(DSKitAsset.Colors.blue500.color, for: .normal)
+            rightButton.setTitleColor(DSKitAsset.Colors.gray400.color, for: .disabled)
             rightButton.titleLabel?.setTypoStyle(.body1)
         }
     }
@@ -195,5 +196,10 @@ extension CustomNavigationBar {
             make.trailing.equalToSuperview().inset(16)
             make.height.equalTo(40)
         }
+    }
+    
+    public func changeRightButtonState(isEnabled: Bool) -> Self {
+        self.rightButton.isEnabled = isEnabled
+        return self
     }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: scene.coordinateSpace.bounds)
         window?.windowScene = scene
-        let rootViewController = ModuleFactory.shared.makePostListVC()
+        let rootViewController = ModuleFactory.shared.makeSplashVC()
         window?.rootViewController = UINavigationController(rootViewController: rootViewController)
         window?.makeKeyAndVisible()
     }


### PR DESCRIPTION
### 🛠 작업 내용
- 회원가입 뷰 인증 이메일 발송 Domain 및 Data Layer 기능 구현
- 커스텀 네비 바 오른쪽 버튼 상태 함수 추가
- 회원가입 관련 뷰 연결

### 🚨 참고 사항
- mock 이메일에서 유효성 여부는 랜덤으로 뜨도록 하였습니다.
- 이메일 형식이 유효한지 확인과 emailTextField 공백 입력 제한은 하지 않았습니다.
- 기기 토큰 받아오는 것은 어느 레이어에서 하면 좋을 지, 그리고 어떻게 관리하면 좋을 지는 논의하면 좋을 것 같아요 . . ~

### 📸 스크린샷
| 이메일 입력 전 | 이메일 입력 후 | 유효하지 않은 이메일 입력 시  |
|:--:|:--:|:--:|
| ![Simulator Screen Shot - iPhone 13 mini - 2022-10-31 at 18 37 10](https://user-images.githubusercontent.com/80062632/198978625-6012d72e-0956-4e84-afae-dc72c89365f0.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-10-31 at 18 37 05](https://user-images.githubusercontent.com/80062632/198978456-fdac855f-4a83-41aa-a5d9-8792a0cb731f.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-10-31 at 18 38 24](https://user-images.githubusercontent.com/80062632/198979357-ad2c7332-2f75-41a2-aaa4-be64da425557.png)|

| 유효한 이메일 입력 시 AuthWaitingVC로 이동 | 게스트 버튼 클릭 시 바로 PostListVC로 이동 |
|:--:|:--:|
| <img src = "https://user-images.githubusercontent.com/80062632/198979296-9e5a63eb-4088-4a73-bf33-42869736f956.png" width = 250> | <img src = "https://user-images.githubusercontent.com/80062632/198979552-f91900d4-f87c-40db-a7a0-5115586b067a.png" width = 250> | 


### 💡 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. -->
- closed: #54  
